### PR TITLE
use RecoilValue instead of RecoilState

### DIFF
--- a/src/RecoilNexus.tsx
+++ b/src/RecoilNexus.tsx
@@ -1,22 +1,22 @@
-import { RecoilState, useRecoilCallback } from 'recoil';
+import { RecoilValue, useRecoilCallback } from 'recoil';
 
 interface Nexus {
-    get?: <T>(atom: RecoilState<T>) => T
-    getPromise?: <T>(atom: RecoilState<T>) => Promise<T>
-    set?: <T>(recoilVal: RecoilState<T>, valOrUpdater: T | ((currVal: T) => T)) => void
+    get?: <T>(atom: RecoilValue<T>) => T
+    getPromise?: <T>(atom: RecoilValue<T>) => Promise<T>
+    set?: <T>(recoilVal: RecoilValue<T>, valOrUpdater: T | ((currVal: T) => T)) => void
 }
 
 const nexus: Nexus = {}
 
 export default function RecoilNexus() {
 
-    nexus.get = useRecoilCallback<[atom: RecoilState<any>], any>(({ snapshot }) =>
-        function <T>(atom: RecoilState<T>) {
+    nexus.get = useRecoilCallback<[atom: RecoilValue<any>], any>(({ snapshot }) =>
+        function <T>(atom: RecoilValue<T>) {
             return snapshot.getLoadable(atom).contents
         }, [])
 
-    nexus.getPromise = useRecoilCallback<[atom: RecoilState<any>], Promise<any>>(({ snapshot }) =>
-        function <T>(atom: RecoilState<T>) {
+    nexus.getPromise = useRecoilCallback<[atom: RecoilValue<any>], Promise<any>>(({ snapshot }) =>
+        function <T>(atom: RecoilValue<T>) {
             return snapshot.getPromise(atom)
         }, [])
 
@@ -25,14 +25,14 @@ export default function RecoilNexus() {
     return null
 }
 
-export function getRecoil<T>(atom: RecoilState<T>): T {
+export function getRecoil<T>(atom: RecoilValue<T>): T {
     return nexus.get!(atom)
 }
 
-export function getRecoilPromise<T>(atom: RecoilState<T>): Promise<T> {
+export function getRecoilPromise<T>(atom: RecoilValue<T>): Promise<T> {
     return nexus.getPromise!(atom)
 }
 
-export function setRecoil<T>(atom: RecoilState<T>, valOrUpdater: T | ((currVal: T) => T)) {
+export function setRecoil<T>(atom: RecoilValue<T>, valOrUpdater: T | ((currVal: T) => T)) {
     nexus.set!(atom, valOrUpdater)
 }

--- a/src/RecoilNexus.tsx
+++ b/src/RecoilNexus.tsx
@@ -1,9 +1,9 @@
-import { RecoilValue, useRecoilCallback } from 'recoil';
+import { RecoilValue, RecoilState, useRecoilCallback } from 'recoil';
 
 interface Nexus {
     get?: <T>(atom: RecoilValue<T>) => T
     getPromise?: <T>(atom: RecoilValue<T>) => Promise<T>
-    set?: <T>(atom: RecoilValue<T>, valOrUpdater: T | ((currVal: T) => T)) => void
+    set?: <T>(atom: RecoilState<T>, valOrUpdater: T | ((currVal: T) => T)) => void
 }
 
 const nexus: Nexus = {}
@@ -33,6 +33,6 @@ export function getRecoilPromise<T>(atom: RecoilValue<T>): Promise<T> {
     return nexus.getPromise!(atom)
 }
 
-export function setRecoil<T>(atom: RecoilValue<T>, valOrUpdater: T | ((currVal: T) => T)) {
+export function setRecoil<T>(atom: RecoilState<T>, valOrUpdater: T | ((currVal: T) => T)) {
     nexus.set!(atom, valOrUpdater)
 }


### PR DESCRIPTION
Hi, me again,

`xport type RecoilValue<T> = RecoilValueReadOnly<T> | RecoilState<T>;`

`useRecoilValue` to enable `RecoilValueReadOnly`

Regards
