### PR TITLE
Update recoil version of peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "Luis Antonio Canettoli Ordoñez",
   "license": "MIT",
   "peerDependencies": {
-    "recoil": "^0.2.0"
+    "recoil": ">=0.2.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Since recoil's version is under 1.0 (=pre-release), "^0.2.0" is recognized as exact only 0.2.0 even if this package supports up to recent version of recoil.