### PR TITLE
Change set method to use map snapshot and gotoSnapshot

### DIFF
--- a/src/RecoilNexus.tsx
+++ b/src/RecoilNexus.tsx
@@ -21,7 +21,15 @@ export default function RecoilNexus() {
             return snapshot.getPromise(atom)
         }, [])
 
-    nexus.set = useRecoilCallback(({ set }) => set, [])
+    nexus.set = useRecoilCallback(({ snapshot, gotoSnapshot }) => {
+        return function <T>(atom: RecoilState<T>, valOrUpdater: T | ((currVal: T) => T)) {
+            const newSnapshot = snapshot.map(mutable => {
+                mutable.set(atom, valOrUpdater)
+            })
+    
+            gotoSnapshot(newSnapshot)
+        }
+    }, [])
 
     nexus.reset = useRecoilCallback(({ reset }) => reset, [])
 


### PR DESCRIPTION
Reworking the set method to instead map to a new snapshot and call `gotoSnapshot` fixes the issue we had in #19.

I haven't had the change to go into a complete deep dive of the recoil source code, but it looks like calling `set` queues the update:

https://github.com/facebookexperimental/Recoil/blob/ff58dd4fceabef61e1a807dd9fe8d7c60db6985b/packages/recoil/hooks/Recoil_useRecoilCallback.js#L75-L76

https://github.com/facebookexperimental/Recoil/blob/ff58dd4fceabef61e1a807dd9fe8d7c60db6985b/packages/recoil/core/Recoil_RecoilValueInterface.js#L254-L264

but if we manually map the snapshot and call `gotoSnapshot` it immediately updates the state:

https://github.com/facebookexperimental/Recoil/blob/ff58dd4fceabef61e1a807dd9fe8d7c60db6985b/packages/recoil/hooks/Recoil_SnapshotHooks.js#L223-L251

which is what we would want when we're calling `setRecoil` from outside a React component, which can wait for the queued batched updates which were probably implemented for performance reasons.

Sorry that I don't have a reproducible example due to time constraints but this is what was immediately observed after I made the changes in this PR:

Before:
```js
console.log('before', getRecoil(someAtom)); // old value
setRecoil(someAtom, newValue); 
console.log('after', getRecoil(someAtom)); // still old value value

setTimeout(() => {
  console.log('after inside timeout', getRecoil(someAtom)); // sometimes new value, sometimes old value
})

setTimeout(() => {
  console.log('after inside long timeout', getRecoil(someAtom)); // new value
}, 1000)
```

After:
```js
console.log('before', getRecoil(someAtom)); // old value
setRecoil(someAtom, newValue); 
console.log('after', getRecoil(someAtom)); // new value
```